### PR TITLE
Fix fmt and clippy checks and address lint warnings raised by Clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,10 @@ matrix:
     install:
     - rustup component add rustfmt-preview
     script:
-    - cargo fmt -- --write-mode=check
+    - cargo fmt --all -- --check
   - env: NAME="lint"
     rust: nightly
     install:
-    - cargo install clippy || echo clippy already installed
+    - rustup component add clippy-preview --toolchain=nightly
     script:
     - cargo clippy


### PR DESCRIPTION
This diff fixes the `rustfmt` check `clippy` CI checks. As discussed in [#5545](https://github.com/rust-lang/cargo/issues/5545) the `rustfmt` option `--write-mode check` is now `--check`. In addition, `clippy` is now a [component of `rustup`](https://internals.rust-lang.org/t/clippy-is-available-as-a-rustup-component/7967) so the recommend way to install it is `rustup component add clippy-preview --toolchain=nightly`. This diff updates the clippy CI test to use that command now and also address some new lints found by it.