### PR TITLE
Replacing standard HashMap with high performant hashbrown HashMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lru"
-version = "0.1.11"
+version = "0.1.12"
 authors = ["Jerome Froelich <jeromefroelic@hotmail.com>"]
 description = "A LRU cache implementation"
 homepage = "https://github.com/jeromefroe/lru-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["LRU", "cache"]
 nightly = []
 
 [dependencies]
+hashbrown = "0.1.*"
 
 [dev-dependencies]
 scoped_threadpool = "0.1.*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,12 +55,12 @@
 //! }
 //! ```
 
+extern crate hashbrown;
 #[cfg(test)]
 extern crate scoped_threadpool;
-extern crate hashbrown;
 
-use hashbrown::HashMap;
 use hashbrown::hash_map::DefaultHashBuilder;
+use hashbrown::HashMap;
 use std::hash::{BuildHasher, Hash, Hasher};
 use std::iter::FusedIterator;
 use std::marker::PhantomData;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,9 +57,10 @@
 
 #[cfg(test)]
 extern crate scoped_threadpool;
+extern crate hashbrown;
 
-use std::collections::hash_map::RandomState;
-use std::collections::HashMap;
+use hashbrown::HashMap;
+use hashbrown::hash_map::DefaultHashBuilder;
 use std::hash::{BuildHasher, Hash, Hasher};
 use std::iter::FusedIterator;
 use std::marker::PhantomData;
@@ -107,7 +108,7 @@ impl<K, V> LruEntry<K, V> {
 }
 
 /// An LRU Cache
-pub struct LruCache<K, V, S = RandomState> {
+pub struct LruCache<K, V, S = DefaultHashBuilder> {
     map: HashMap<KeyRef<K>, Box<LruEntry<K, V>>, S>,
     cap: usize,
 
@@ -149,11 +150,13 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     /// # Example
     ///
     /// ```
-    /// use std::collections::HashMap;
-    /// use std::collections::hash_map::RandomState;
+    /// extern crate hashbrown;
+    /// use hashbrown;
+    /// use hashbrown::HashMap;
+    /// use hashbrown::hash_map::DefaultHashBuilder;
     /// use lru::LruCache;
     ///
-    /// let s = RandomState::new();
+    /// let s = DefaultHashBuilder::default();
     /// let mut cache: LruCache<isize, &str> = LruCache::with_hasher(10, s);
     /// ```
     pub fn with_hasher(cap: usize, hash_builder: S) -> LruCache<K, V, S> {
@@ -773,9 +776,9 @@ mod tests {
 
     #[test]
     fn test_with_hasher() {
-        use std::collections::hash_map::RandomState;
+        use hashbrown::hash_map::DefaultHashBuilder;
 
-        let s = RandomState::new();
+        let s = DefaultHashBuilder::default();;
         let mut cache = LruCache::with_hasher(16, s);
 
         for i in 0..13370 {


### PR DESCRIPTION
[Hashbrown HashMap](https://crates.io/crates/hashbrown) implementation is more efficient and high performant compared to standard HashMap implementation.

```
* Drop-in replacement for the standard library HashMap and HashSet types.
* Uses FxHash as the default hasher, which is much faster than SipHash.
* Around 2x faster than FxHashMap and 8x faster than the standard HashMap.
* Lower memory usage: only 1 byte of overhead per entry instead of 8.
* Compatible with #[no_std] (currently requires nightly for the alloc crate).
* Empty hash maps do not allocate any memory.
* SIMD lookups to scan multiple hash entries in parallel.
``` 


