### PR TITLE
Return old value if it exists from put method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
 # LRU Cache
 
-[![Build Status](https://travis-ci.org/jeromefroe/lru-rs.svg?branch=master)](https://travis-ci.org/jeromefroe/lru-rs)
-[![codecov](https://codecov.io/gh/jeromefroe/lru-rs/branch/master/graph/badge.svg)](https://codecov.io/gh/jeromefroe/lru-rs)
-[![crates.io](https://img.shields.io/crates/v/lru.svg)](https://crates.io/crates/lru/)
-[![docs.rs](https://docs.rs/lru/badge.svg)](https://docs.rs/lru/)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/jeromefroe/lru-rs/master/LICENSE)
+[![Travis Badge]][build status]
+[![Codecov Badge]][coverage status]
+[![crates.io Badge]][crates.io package]
+[![docs.rs Badge]][docs.rs documentation]
+[![License Badge]][license]
 
-[Documentation](https://docs.rs/lru/)
+[Documentation]
 
 An implementation of a LRU cache. The cache supports `put`, `get`, `get_mut` and `pop` operations,
-all of which are O(1). This crate was heavily influenced by the
-[LRU Cache implementation in an earlier version of Rust's std::collections crate](https://doc.rust-lang.org/0.12.0/std/collections/lru_cache/struct.LruCache.html).
-
+all of which are O(1). This crate was heavily influenced by the [LRU Cache implementation in an
+earlier version of Rust's std::collections crate].
 
 ## Example
 
@@ -31,10 +30,11 @@ fn main() {
     assert_eq!(*cache.get(&"banana").unwrap(), 2);
     assert!(cache.get(&"pear").is_none());
 
-    cache.put("pear", 4);
+    assert_eq!(cache.put("banana", 4), Some(2));
+    assert_eq!(cache.put("pear", 5), None);
 
-    assert_eq!(*cache.get(&"pear").unwrap(), 4);
-    assert_eq!(*cache.get(&"banana").unwrap(), 2);
+    assert_eq!(*cache.get(&"pear").unwrap(), 5);
+    assert_eq!(*cache.get(&"banana").unwrap(), 4);
     assert!(cache.get(&"apple").is_none());
 
     {
@@ -45,3 +45,16 @@ fn main() {
     assert_eq!(*cache.get(&"banana").unwrap(), 6);
 }
 ```
+
+[travis badge]: https://travis-ci.org/jeromefroe/lru-rs.svg?branch=master
+[build status]: https://travis-ci.org/jeromefroe/lru-rs
+[codecov badge]: https://codecov.io/gh/jeromefroe/lru-rs/branch/master/graph/badge.svg
+[coverage status]: https://codecov.io/gh/jeromefroe/lru-rs
+[crates.io badge]: https://img.shields.io/crates/v/lru.svg
+[crates.io package]: https://crates.io/crates/lru/
+[documentation]: https://docs.rs/lru/
+[docs.rs badge]: https://docs.rs/lru/badge.svg
+[docs.rs documentation]: (https://docs.rs/lru/)
+[license badge]: https://img.shields.io/badge/license-MIT-blue.svg
+[license]: (https://raw.githubusercontent.com/jeromefroe/lru-rs/master/LICENSE)
+[lru cache implementation in an earlier version of rust's std::collections crate]: https://doc.rust-lang.org/0.12.0/std/collections/lru_cache/struct.LruCache.html


### PR DESCRIPTION
This commit updates the `put` method to return an `Option` instead of nothing. If a value already exists for the key that is being inserted into the cache then `put` returns that old value. Otherwise, if the key is not in the cache it returns `None`.

Fixes #43.