### PR TITLE
Fix Link in documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 
 //! An implementation of a LRU cache. The cache supports `get`, `get_mut`, `put`,
 //! and `pop` operations, all of which are O(1). This crate was heavily influenced
-//! by the [LRU Cache implementation in an earlier version of Rust's std::collections crate] (https://doc.rust-lang.org/0.12.0/std/collections/lru_cache/struct.LruCache.html).
+//! by the [LRU Cache implementation in an earlier version of Rust's std::collections crate](https://doc.rust-lang.org/0.12.0/std/collections/lru_cache/struct.LruCache.html).
 //!
 //! ## Example
 //!


### PR DESCRIPTION
See https://docs.rs/lru/0.3.1/lru/ for the broken link to the old `std::collections`. Removing the space fix this.