### PR TITLE
Use mem::MaybeUninit instead of mem::uninitialized

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,8 +214,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
         let cache = LruCache {
             map,
             cap,
-            head: unsafe { Box::into_raw(Box::new(mem::uninitialized::<LruEntry<K, V>>())) },
-            tail: unsafe { Box::into_raw(Box::new(mem::uninitialized::<LruEntry<K, V>>())) },
+            head: unsafe { Box::into_raw(Box::new(mem::MaybeUninit::uninit().assume_init())) },
+            tail: unsafe { Box::into_raw(Box::new(mem::MaybeUninit::uninit().assume_init())) },
         };
 
         unsafe {


### PR DESCRIPTION
This commit replaces the use of `std::mem::uninitialized` with `std::mem::MaybeUninit` because the former has been deprecated in favor of the latter.

Fixes #61 