### PR TITLE
Make hashbrown optional (but default)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,3 +52,7 @@ matrix:
     - rustup component add clippy
     script:
     - cargo clippy
+  - env: NAME="no-hashbrown"
+    rust: stable
+    script:
+    - cargo test --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,11 @@ license = "MIT"
 keywords = ["LRU", "cache"]
 
 [features]
-nightly = ["hashbrown/nightly"]
+default = ["hashbrown"]
+nightly = ["hashbrown", "hashbrown/nightly"]
 
 [dependencies]
-hashbrown = "0.6.*"
+hashbrown = { version = "0.6.*", optional = true }
 
 [dev-dependencies]
 scoped_threadpool = "0.1.*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@
 #![no_std]
 #![cfg_attr(feature = "nightly", feature(alloc, optin_builtin_traits))]
 
+#[cfg(feature = "hashbrown")]
 extern crate hashbrown;
 
 #[cfg(test)]
@@ -76,8 +77,11 @@ use core::marker::PhantomData;
 use core::mem;
 use core::ptr;
 use core::usize;
-use hashbrown::hash_map::DefaultHashBuilder;
+
+#[cfg(feature = "hashbrown")]
 use hashbrown::HashMap;
+#[cfg(not(feature = "hashbrown"))]
+use alloc::collections::HashMap;
 
 #[cfg(test)]
 #[macro_use]
@@ -151,8 +155,13 @@ impl<K, V> LruEntry<K, V> {
     }
 }
 
+#[cfg(feature = "hashbrown")]
+type DefaultHasher = hashbrown::hash_map::DefaultHashBuilder;
+#[cfg(not(feature = "hashbrown"))]
+type DefaultHasher = alloc::collections::hash_map::RandomState;
+
 /// An LRU Cache
-pub struct LruCache<K, V, S = DefaultHashBuilder> {
+pub struct LruCache<K, V, S = DefaultHasher> {
     map: HashMap<KeyRef<K>, Box<LruEntry<K, V>>, S>,
     cap: usize,
 
@@ -979,6 +988,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "hashbrown")]
     fn test_with_hasher() {
         use hashbrown::hash_map::DefaultHashBuilder;
 


### PR DESCRIPTION
Changes the hashbrown dependency to an optional one for users that prefer to rely on the std hashmap implementation. The dependency is enabled by default.

I also added an extra Travis test that tests the implementation without using hashbrown.