### PR TITLE
Add MSRV documentation and Travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ matrix:
       for file in target/debug/lru-*[^\.d]; do mkdir -p "target/cov/$(basename $file)"; ./kcov-build/usr/local/bin/kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
       bash <(curl -s https://codecov.io/bash) &&
       echo "Uploaded code coverage"
+  - env: NAME="msrv"
+    rust: 1.36.0
   - env: NAME="beta"
     rust: beta
   - env: NAME="nightly"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ An implementation of a LRU cache. The cache supports `put`, `get`, `get_mut` and
 all of which are O(1). This crate was heavily influenced by the [LRU Cache implementation in an
 earlier version of Rust's std::collections crate].
 
+The MSRV for this crate is 1.36.0.
+
 ## Example
 
 Below is a simple example of how to instantiate and use a LRU cache.


### PR DESCRIPTION
The current minimum supported Rust version is 1.36.0 (because of `mem::MaybeUninit` usage).

I documented this in the README and I added a Travis test to make sure the MSRV is not broken unexpectedly. This is important because when MSRV changes, the major semver version should be bumped.