### PR TITLE
Make key and val fields of LRUEntry Options

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -746,33 +746,6 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     }
 }
 
-impl<K, V, S> Drop for LruCache<K, V, S> {
-    fn drop(&mut self) {
-        // Prevent compiler from trying to drop the un-initialized fields key and val in head
-        // and tail
-        unsafe {
-            let head = *Box::from_raw(self.head);
-            let tail = *Box::from_raw(self.tail);
-
-            let LruEntry {
-                key: head_key,
-                val: head_val,
-                ..
-            } = head;
-            let LruEntry {
-                key: tail_key,
-                val: tail_val,
-                ..
-            } = tail;
-
-            mem::forget(head_key);
-            mem::forget(head_val);
-            mem::forget(tail_key);
-            mem::forget(tail_val);
-        }
-    }
-}
-
 impl<'a, K: Hash + Eq, V, S: BuildHasher> IntoIterator for &'a LruCache<K, V, S> {
     type Item = (&'a K, &'a V);
     type IntoIter = Iter<'a, K, V>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,9 +278,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
             None => {
                 let mut node = if self.len() == self.cap() {
                     // if the cache is full, remove the last entry so we can use it for the new key
-                    let old_node = self.remove_last();
-
-                    let mut old_node = match old_node {
+                    let mut old_node = match self.remove_last() {
                         Some(node) => node,
                         // if there is no last node then the capacity of the cache must be 0 so we
                         // can just return None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -746,6 +746,15 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     }
 }
 
+impl<K, V, S> Drop for LruCache<K, V, S> {
+    fn drop(&mut self) {
+        unsafe {
+            ptr::drop_in_place(self.head);
+            ptr::drop_in_place(self.tail);
+        }
+    }
+}
+
 impl<'a, K: Hash + Eq, V, S: BuildHasher> IntoIterator for &'a LruCache<K, V, S> {
     type Item = (&'a K, &'a V);
     type IntoIter = Iter<'a, K, V>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -716,8 +716,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     }
 
     fn remove_last(&mut self) -> Option<Box<LruEntry<K, V>>> {
-        let prev;
-        unsafe { prev = (*self.tail).prev }
+        let prev = unsafe { (*self.tail).prev };
         if prev != self.head {
             let old_key = KeyRef {
                 k: unsafe { &(*(*self.tail).prev).kv.as_ref().unwrap().key },


### PR DESCRIPTION
This commit addresses the improper use of `MaybeUninit` as discussed in #70. By making the `key` and `val` fields of `LRUEntry` an `Option` we can no longer need to construct an `LRUEntry` for the head and tail of the cache with uninitialized memory for these fields. Instead, they can just be set to `None` and we enforce in the rest of the crate that all other entries of the cache contain a value for these fields. This change has the added benefit of allowing us to simplify the `Drop` method for `LRUCache` since we no longer need to manually ensure the compiler doesn't drop the `key` and `val` fields of the head and tail entries.