### PR TITLE
Always use alloc crate, it's stable now

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,16 +57,13 @@
 //! ```
 
 #![no_std]
-#![cfg_attr(feature = "nightly", feature(alloc, optin_builtin_traits))]
+#![cfg_attr(feature = "nightly", feature(optin_builtin_traits))]
 
 #[cfg(feature = "hashbrown")]
 extern crate hashbrown;
 
 #[cfg(test)]
 extern crate scoped_threadpool;
-
-#[cfg(not(feature = "nightly"))]
-extern crate std as alloc;
 
 use alloc::borrow::Borrow;
 use alloc::boxed::Box;
@@ -87,7 +84,6 @@ use hashbrown::HashMap;
 #[macro_use]
 extern crate std;
 
-#[cfg(feature = "nightly")]
 extern crate alloc;
 
 // Struct used to hold a reference to a key

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,14 +75,13 @@ use core::mem;
 use core::ptr;
 use core::usize;
 
-#[cfg(not(feature = "hashbrown"))]
-use alloc::collections::HashMap;
+#[cfg(any(test, not(feature = "hashbrown")))]
+extern crate std;
+
 #[cfg(feature = "hashbrown")]
 use hashbrown::HashMap;
-
-#[cfg(test)]
-#[macro_use]
-extern crate std;
+#[cfg(not(feature = "hashbrown"))]
+use std::collections::HashMap;
 
 extern crate alloc;
 
@@ -163,7 +162,7 @@ impl<K, V> LruEntry<K, V> {
 #[cfg(feature = "hashbrown")]
 pub type DefaultHasher = hashbrown::hash_map::DefaultHashBuilder;
 #[cfg(not(feature = "hashbrown"))]
-pub type DefaultHasher = alloc::collections::hash_map::RandomState;
+pub type DefaultHasher = std::collections::hash_map::RandomState;
 
 /// An LRU Cache
 pub struct LruCache<K, V, S = DefaultHasher> {


### PR DESCRIPTION
[Alloc has been stable since 1.36.0](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1360-2019-07-04), this crate's MSRV is 1.36.0. Therefore, there is no point in gating access to the alloc crate behind the nightly flag.

This change allows using this crate in no_std environment on stable rust.