### PR TITLE
Update to latest hashbrown, fix determinism of build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default = ["hashbrown"]
 nightly = ["hashbrown", "hashbrown/nightly"]
 
 [dependencies]
-hashbrown = { version = "0.6.*", optional = true }
+hashbrown = { version = "0.8.0", optional = true }
 
 [dev-dependencies]
 scoped_threadpool = "0.1.*"


### PR DESCRIPTION
This PR updates hashbrown to the latest release (`0.8.0`). 

In the 0.6 series hashbrown's default feature set activated the [compile-time-rng-feature in ahash](https://github.com/rust-lang/hashbrown/blob/efbd03661fc9df0e594ecc89784107353cc71060/Cargo.toml#L45), the internally used hasher – which lead to non-deterministic builds even on the same system. In the latest series this feature is not enabled by hashbrown by default anymore. Updating to that series fixes that problem.

As far as I can tell, this could be released as a non-breaking patch release.