### PR TITLE
Update hashbrown to ^0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default = ["hashbrown"]
 nightly = ["hashbrown", "hashbrown/nightly"]
 
 [dependencies]
-hashbrown = { version = "0.8.0", optional = true }
+hashbrown = { version = "0.9.0", optional = true }
 
 [dev-dependencies]
 scoped_threadpool = "0.1.*"


### PR DESCRIPTION
This allows us to follow any patch release in hashbrown.

The only breaking change betwen hashbrown 0.8 and 0.9 is in the `drain_filter function`, which we don't use.

I choose to set the version to `0.9.0`, which is short for `^0.9.0` and allows any `0.9.x`. The latest `0.9.1` would be used by default but we don't require it here.

As far as I can see, this is a non-breaking change for lru users.