### PR TITLE
Specify iteration order explicitly in documentation.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -657,7 +657,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
         }
     }
 
-    /// An iterator visiting all entries in order. The iterator element type is `(&'a K, &'a V)`.
+    /// An iterator visiting all entries in most-recently used order. The iterator element type is
+    /// `(&'a K, &'a V)`.
     ///
     /// # Examples
     ///
@@ -682,8 +683,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
         }
     }
 
-    /// An iterator visiting all entries in order, giving a mutable reference on V.
-    /// The iterator element type is `(&'a K, &'a mut V)`.
+    /// An iterator visiting all entries in most-recently-used order, giving a mutable reference on
+    /// V.  The iterator element type is `(&'a K, &'a mut V)`.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Maybe it should be obvious but I had to write a quick test to figure out the order.

Please feel free to rewrite however you like or just make your own commit if you can think of a better wording, whatever is most convenient. I considered just "in mru order".

Thanks for the crate! It's probably overkill performance-wise for managing Emacs yanks, but I try not to even implement left pad myself if I can help it.