### PR TITLE
send/sync bounds should apply to all conforming hashers, not just default one

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -787,8 +787,8 @@ impl<'a, K: Hash + Eq, V, S: BuildHasher> IntoIterator for &'a mut LruCache<K, V
 // The compiler does not automatically derive Send and Sync for LruCache because it contains
 // raw pointers. The raw pointers are safely encapsulated by LruCache though so we can
 // implement Send and Sync for it below.
-unsafe impl<K: Send, V: Send> Send for LruCache<K, V> {}
-unsafe impl<K: Sync, V: Sync> Sync for LruCache<K, V> {}
+unsafe impl<K: Send, V: Send, S: Send> Send for LruCache<K, V, S> {}
+unsafe impl<K: Sync, V: Sync, S: Sync> Sync for LruCache<K, V, S> {}
 
 impl<K: Hash + Eq, V> fmt::Debug for LruCache<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
hey there, should be pretty self-explanatory.