### PR TITLE
Explicitly implement Borrow for Box for non-nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,13 @@ impl Borrow<str> for KeyRef<alloc::string::String> {
 }
 
 #[cfg(not(feature = "nightly"))]
+impl<T: ?Sized> Borrow<T> for KeyRef<Box<T>> {
+    fn borrow(&self) -> &T {
+        unsafe { &*self.k }
+    }
+}
+
+#[cfg(not(feature = "nightly"))]
 impl<T> Borrow<[T]> for KeyRef<alloc::vec::Vec<T>> {
     fn borrow(&self) -> &[T] {
         unsafe { &*self.k }


### PR DESCRIPTION
Useful for Box<T: Unsized> like Box<[T]> or Box<str>.

Follows 075a23de6d525373f39b8ef3c7907464620e27bf