### PR TITLE
Add a get_or_insert method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,6 +413,82 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
         }
     }
 
+    /// Returns a reference to the value of the key in the cache if it is
+    /// present in the cache and moves the key to the head of the LRU list.
+    /// If the key does not exist the provided `Fn` is used to populate the list and a reference
+    /// is returned.
+    ///
+    /// This method will only return `None` when the capacity of the cache is 0 and no entries
+    /// can be populated.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lru::LruCache;
+    /// let mut cache = LruCache::new(2);
+    ///
+    /// cache.put(1, "a");
+    /// cache.put(2, "b");
+    /// cache.put(2, "c");
+    /// cache.put(3, "d");
+    ///
+    /// assert_eq!(cache.get_or_insert(2, ||"a"), Some(&"c"));
+    /// assert_eq!(cache.get_or_insert(3, ||"a"), Some(&"d"));
+    /// assert_eq!(cache.get_or_insert(1, ||"a"), Some(&"a"));
+    /// assert_eq!(cache.get_or_insert(1, ||"b"), Some(&"a"));
+    /// ```
+    pub fn get_or_insert<'a, F>(&mut self, k: K, f: F) -> Option<&'a V>
+        where
+            F: Fn() -> V,
+    {
+        if let Some(node) = self.map.get_mut(&k) {
+            let node_ptr: *mut LruEntry<K, V> = &mut **node;
+
+            self.detach(node_ptr);
+            self.attach(node_ptr);
+
+            Some(unsafe { &(*(*node_ptr).val.as_ptr()) as &V })
+        } else {
+            // If the capacity is 0 we do nothing,
+            // this is the only circumstance that should return None
+            if self.cap() == 0 {
+                return None
+            }
+            let v = f();
+            let mut node = if self.len() == self.cap(){
+                // if the cache is full, remove the last entry so we can use it for the new key
+                let old_key = KeyRef {
+                    k: unsafe { &(*(*(*self.tail).prev).key.as_ptr()) },
+                };
+                let mut old_node = self.map.remove(&old_key).unwrap();
+
+                // drop the node's current key and val so we can overwrite them
+                unsafe {
+                    ptr::drop_in_place(old_node.key.as_mut_ptr());
+                    ptr::drop_in_place(old_node.val.as_mut_ptr());
+                }
+
+                old_node.key = mem::MaybeUninit::new(k);
+                old_node.val = mem::MaybeUninit::new(v);
+
+                let node_ptr: *mut LruEntry<K, V> = &mut *old_node;
+                self.detach(node_ptr);
+
+                old_node
+            } else {
+                // if the cache is not full allocate a new LruEntry
+                Box::new(LruEntry::new(k, v))
+            };
+
+            let node_ptr: *mut LruEntry<K, V> = &mut *node;
+            self.attach(node_ptr);
+
+            let keyref = unsafe { (*node_ptr).key.as_ptr() };
+            self.map.insert(KeyRef { k: keyref }, node);
+            Some(unsafe { &(*(*node_ptr).val.as_ptr()) as &V })
+        }
+    }
+
     /// Returns a reference to the value corresponding to the key in the cache or `None` if it is
     /// not present in the cache. Unlike `get`, `peek` does not update the LRU list so the key's
     /// position will be unchanged.
@@ -1048,6 +1124,23 @@ mod tests {
         assert!(!cache.is_empty());
         assert_opt_eq(cache.get(&"apple"), "red");
         assert_opt_eq(cache.get(&"banana"), "yellow");
+    }
+
+    #[test]
+    fn test_put_and_get_or_insert() {
+        let mut cache = LruCache::new(2);
+        assert!(cache.is_empty());
+
+        assert_eq!(cache.put("apple", "red"), None);
+        assert_eq!(cache.put("banana", "yellow"), None);
+
+        assert_eq!(cache.cap(), 2);
+        assert_eq!(cache.len(), 2);
+        assert!(!cache.is_empty());
+        assert_opt_eq(cache.get_or_insert(&"apple", ||"orange"), &"red");
+        assert_opt_eq(cache.get_or_insert(&"banana", ||"orange"), &"yellow");
+        assert_opt_eq(cache.get_or_insert(&"lemon", ||"orange"), &"orange");
+        assert_opt_eq(cache.get_or_insert(&"lemon", ||"red"), &"orange");
     }
 
     #[test]


### PR DESCRIPTION
Adds a proposed method to get a reference to the entry if it exists.
Otherwise it uses the provided function to populate an entry and returns a reference to that new value.