### PR TITLE
Add new insertion function that allows handling of all removed entries from the cache

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,7 +333,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     /// assert_eq!(None, cache.push(1, "a"));
     /// assert_eq!(None, cache.push(2, "b"));
     ///
-    /// // This push call returns (2, "b") because that was the previously 2's entry in the cache.
+    /// // This push call returns (2, "b") because that was previously 2's entry in the cache.
     /// assert_eq!(Some((2, "b")), cache.push(2, "beta"));
     ///
     /// // This push call returns (1, "a") because the cache is at capacity and 1's entry was the lru entry.


### PR DESCRIPTION
This function adds the function `push` that behaves exactly the same as `put`, except rather than just returning `Some(..)` when the insertion overwrites an entry with the same key, also returns `Some(..)` when the insertion overwrites an entry with a different key. This means that a user can now take ownership of entries that would be dropped because the cache is at capacity. For example:

```rust
let mut cache = LruCache::new(1);

 // Put "a" into the cache with key 0
cache.push(0, "a");

// Put "b" into the cache with key 1, and take ownership of the old key-value pair
// that has been popped from the cache due to its capacity.
assert_eq!(Some((0, "a")), cache.push(1, "b")); 
```