### PR TITLE
replace usize with NonZeroUsize for LRU's capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ Below is a simple example of how to instantiate and use a LRU cache.
 extern crate lru;
 
 use lru::LruCache;
+use std::num::NonZeroUsize;
 
 fn main() {
-    let mut cache = LruCache::new(2);
+    let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
     cache.put("apple", 3);
     cache.put("banana", 2);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,9 +30,10 @@
 //! extern crate lru;
 //!
 //! use lru::LruCache;
+//! use std::num::NonZeroUsize;
 //!
 //! fn main() {
-//!         let mut cache = LruCache::new(2);
+//!         let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
 //!         cache.put("apple", 3);
 //!         cache.put("banana", 2);
 //!
@@ -72,6 +73,7 @@ use core::hash::{BuildHasher, Hash, Hasher};
 use core::iter::FusedIterator;
 use core::marker::PhantomData;
 use core::mem;
+use core::num::NonZeroUsize;
 use core::ptr;
 use core::usize;
 
@@ -188,7 +190,7 @@ pub type DefaultHasher = std::collections::hash_map::RandomState;
 /// An LRU Cache
 pub struct LruCache<K, V, S = DefaultHasher> {
     map: HashMap<KeyRef<K>, Box<LruEntry<K, V>>, S>,
-    cap: usize,
+    cap: NonZeroUsize,
 
     // head and tail are sigil nodes to faciliate inserting entries
     head: *mut LruEntry<K, V>,
@@ -202,10 +204,11 @@ impl<K: Hash + Eq, V> LruCache<K, V> {
     ///
     /// ```
     /// use lru::LruCache;
-    /// let mut cache: LruCache<isize, &str> = LruCache::new(10);
+    /// use std::num::NonZeroUsize;
+    /// let mut cache: LruCache<isize, &str> = LruCache::new(NonZeroUsize::new(10).unwrap());
     /// ```
-    pub fn new(cap: usize) -> LruCache<K, V> {
-        LruCache::construct(cap, HashMap::with_capacity(cap))
+    pub fn new(cap: NonZeroUsize) -> LruCache<K, V> {
+        LruCache::construct(cap, HashMap::with_capacity(cap.get()))
     }
 
     /// Creates a new LRU Cache that never automatically evicts items.
@@ -214,10 +217,11 @@ impl<K: Hash + Eq, V> LruCache<K, V> {
     ///
     /// ```
     /// use lru::LruCache;
+    /// use std::num::NonZeroUsize;
     /// let mut cache: LruCache<isize, &str> = LruCache::unbounded();
     /// ```
     pub fn unbounded() -> LruCache<K, V> {
-        LruCache::construct(usize::MAX, HashMap::default())
+        LruCache::construct(NonZeroUsize::new(usize::MAX).unwrap(), HashMap::default())
     }
 }
 
@@ -229,12 +233,16 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     ///
     /// ```
     /// use lru::{LruCache, DefaultHasher};
+    /// use std::num::NonZeroUsize;
     ///
     /// let s = DefaultHasher::default();
-    /// let mut cache: LruCache<isize, &str> = LruCache::with_hasher(10, s);
+    /// let mut cache: LruCache<isize, &str> = LruCache::with_hasher(NonZeroUsize::new(10).unwrap(), s);
     /// ```
-    pub fn with_hasher(cap: usize, hash_builder: S) -> LruCache<K, V, S> {
-        LruCache::construct(cap, HashMap::with_capacity_and_hasher(cap, hash_builder))
+    pub fn with_hasher(cap: NonZeroUsize, hash_builder: S) -> LruCache<K, V, S> {
+        LruCache::construct(
+            cap,
+            HashMap::with_capacity_and_hasher(cap.into(), hash_builder),
+        )
     }
 
     /// Creates a new LRU Cache that never automatically evicts items and
@@ -249,11 +257,17 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     /// let mut cache: LruCache<isize, &str> = LruCache::unbounded_with_hasher(s);
     /// ```
     pub fn unbounded_with_hasher(hash_builder: S) -> LruCache<K, V, S> {
-        LruCache::construct(usize::MAX, HashMap::with_hasher(hash_builder))
+        LruCache::construct(
+            NonZeroUsize::new(usize::MAX).unwrap(),
+            HashMap::with_hasher(hash_builder),
+        )
     }
 
     /// Creates a new LRU Cache with the given capacity.
-    fn construct(cap: usize, map: HashMap<KeyRef<K>, Box<LruEntry<K, V>>, S>) -> LruCache<K, V, S> {
+    fn construct(
+        cap: NonZeroUsize,
+        map: HashMap<KeyRef<K>, Box<LruEntry<K, V>>, S>,
+    ) -> LruCache<K, V, S> {
         // NB: The compiler warns that cache does not need to be marked as mutable if we
         // declare it as such since we only mutate it inside the unsafe block.
         let cache = LruCache {
@@ -278,7 +292,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     ///
     /// ```
     /// use lru::LruCache;
-    /// let mut cache = LruCache::new(2);
+    /// use std::num::NonZeroUsize;
+    /// let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
     ///
     /// assert_eq!(None, cache.put(1, "a"));
     /// assert_eq!(None, cache.put(2, "b"));
@@ -299,7 +314,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     ///
     /// ```
     /// use lru::LruCache;
-    /// let mut cache = LruCache::new(2);
+    /// use std::num::NonZeroUsize;
+    /// let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
     ///
     /// assert_eq!(None, cache.push(1, "a"));
     /// assert_eq!(None, cache.push(2, "b"));
@@ -336,11 +352,6 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
                 Some((k, v))
             }
             None => {
-                // if the capacity is zero, do nothing
-                if self.cap() == 0 {
-                    return None;
-                }
-
                 let (replaced, mut node) = self.replace_or_create_node(k, v);
 
                 let node_ptr: *mut LruEntry<K, V> = &mut *node;
@@ -358,7 +369,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     // is available. Shared between `put`, `push`, and `get_or_insert`.
     #[allow(clippy::type_complexity)]
     fn replace_or_create_node(&mut self, k: K, v: V) -> (Option<(K, V)>, Box<LruEntry<K, V>>) {
-        if self.len() == self.cap() {
+        if self.len() == self.cap().get() {
             // if the cache is full, remove the last entry so we can use it for the new key
             let old_key = KeyRef {
                 k: unsafe { &(*(*(*self.tail).prev).key.as_ptr()) },
@@ -388,7 +399,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     ///
     /// ```
     /// use lru::LruCache;
-    /// let mut cache = LruCache::new(2);
+    /// use std::num::NonZeroUsize;
+    /// let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
     ///
     /// cache.put(1, "a");
     /// cache.put(2, "b");
@@ -423,7 +435,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     ///
     /// ```
     /// use lru::LruCache;
-    /// let mut cache = LruCache::new(2);
+    /// use std::num::NonZeroUsize;
+    /// let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
     ///
     /// cache.put("apple", 8);
     /// cache.put("banana", 4);
@@ -456,26 +469,24 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     /// If the key does not exist the provided `FnOnce` is used to populate
     /// the list and a reference is returned.
     ///
-    /// This method will only return `None` when the capacity of the cache is 0 and no entries
-    /// can be populated.
-    ///
     /// # Example
     ///
     /// ```
     /// use lru::LruCache;
-    /// let mut cache = LruCache::new(2);
+    /// use std::num::NonZeroUsize;
+    /// let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
     ///
     /// cache.put(1, "a");
     /// cache.put(2, "b");
     /// cache.put(2, "c");
     /// cache.put(3, "d");
     ///
-    /// assert_eq!(cache.get_or_insert(2, ||"a"), Some(&"c"));
-    /// assert_eq!(cache.get_or_insert(3, ||"a"), Some(&"d"));
-    /// assert_eq!(cache.get_or_insert(1, ||"a"), Some(&"a"));
-    /// assert_eq!(cache.get_or_insert(1, ||"b"), Some(&"a"));
+    /// assert_eq!(cache.get_or_insert(2, ||"a"), &"c");
+    /// assert_eq!(cache.get_or_insert(3, ||"a"), &"d");
+    /// assert_eq!(cache.get_or_insert(1, ||"a"), &"a");
+    /// assert_eq!(cache.get_or_insert(1, ||"b"), &"a");
     /// ```
-    pub fn get_or_insert<'a, F>(&mut self, k: K, f: F) -> Option<&'a V>
+    pub fn get_or_insert<'a, F>(&mut self, k: K, f: F) -> &'a V
     where
         F: FnOnce() -> V,
     {
@@ -485,13 +496,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
             self.detach(node_ptr);
             self.attach(node_ptr);
 
-            Some(unsafe { &(*(*node_ptr).val.as_ptr()) as &V })
+            unsafe { &(*(*node_ptr).val.as_ptr()) as &V }
         } else {
-            // If the capacity is 0 we do nothing,
-            // this is the only circumstance that should return None
-            if self.cap() == 0 {
-                return None;
-            }
             let v = f();
             let (_, mut node) = self.replace_or_create_node(k, v);
 
@@ -500,7 +506,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
 
             let keyref = unsafe { (*node_ptr).key.as_ptr() };
             self.map.insert(KeyRef { k: keyref }, node);
-            Some(unsafe { &(*(*node_ptr).val.as_ptr()) as &V })
+            unsafe { &(*(*node_ptr).val.as_ptr()) as &V }
         }
     }
 
@@ -512,7 +518,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     ///
     /// ```
     /// use lru::LruCache;
-    /// let mut cache = LruCache::new(2);
+    /// use std::num::NonZeroUsize;
+    /// let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
     ///
     /// cache.put(1, "a");
     /// cache.put(2, "b");
@@ -538,7 +545,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     ///
     /// ```
     /// use lru::LruCache;
-    /// let mut cache = LruCache::new(2);
+    /// use std::num::NonZeroUsize;
+    /// let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
     ///
     /// cache.put(1, "a");
     /// cache.put(2, "b");
@@ -565,7 +573,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     ///
     /// ```
     /// use lru::LruCache;
-    /// let mut cache = LruCache::new(2);
+    /// use std::num::NonZeroUsize;
+    /// let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
     ///
     /// cache.put(1, "a");
     /// cache.put(2, "b");
@@ -594,7 +603,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     ///
     /// ```
     /// use lru::LruCache;
-    /// let mut cache = LruCache::new(2);
+    /// use std::num::NonZeroUsize;
+    /// let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
     ///
     /// cache.put(1, "a");
     /// cache.put(2, "b");
@@ -619,7 +629,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     ///
     /// ```
     /// use lru::LruCache;
-    /// let mut cache = LruCache::new(2);
+    /// use std::num::NonZeroUsize;
+    /// let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
     ///
     /// cache.put(2, "a");
     ///
@@ -653,7 +664,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     ///
     /// ```
     /// use lru::LruCache;
-    /// let mut cache = LruCache::new(2);
+    /// use std::num::NonZeroUsize;
+    /// let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
     ///
     /// cache.put(1, "a");
     /// cache.put(2, "a");
@@ -686,7 +698,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     ///
     /// ```
     /// use lru::LruCache;
-    /// let mut cache = LruCache::new(2);
+    /// use std::num::NonZeroUsize;
+    /// let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
     ///
     /// cache.put(2, "a");
     /// cache.put(3, "b");
@@ -712,7 +725,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     ///
     /// ```
     /// use lru::LruCache;
-    /// let mut cache = LruCache::new(2);
+    /// use std::num::NonZeroUsize;
+    /// let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
     /// assert_eq!(cache.len(), 0);
     ///
     /// cache.put(1, "a");
@@ -734,7 +748,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     ///
     /// ```
     /// use lru::LruCache;
-    /// let mut cache = LruCache::new(2);
+    /// use std::num::NonZeroUsize;
+    /// let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
     /// assert!(cache.is_empty());
     ///
     /// cache.put(1, "a");
@@ -750,10 +765,11 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     ///
     /// ```
     /// use lru::LruCache;
-    /// let mut cache: LruCache<isize, &str> = LruCache::new(2);
-    /// assert_eq!(cache.cap(), 2);
+    /// use std::num::NonZeroUsize;
+    /// let mut cache: LruCache<isize, &str> = LruCache::new(NonZeroUsize::new(2).unwrap());
+    /// assert_eq!(cache.cap().get(), 2);
     /// ```
-    pub fn cap(&self) -> usize {
+    pub fn cap(&self) -> NonZeroUsize {
         self.cap
     }
 
@@ -764,11 +780,12 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     ///
     /// ```
     /// use lru::LruCache;
-    /// let mut cache: LruCache<isize, &str> = LruCache::new(2);
+    /// use std::num::NonZeroUsize;
+    /// let mut cache: LruCache<isize, &str> = LruCache::new(NonZeroUsize::new(2).unwrap());
     ///
     /// cache.put(1, "a");
     /// cache.put(2, "b");
-    /// cache.resize(4);
+    /// cache.resize(NonZeroUsize::new(4).unwrap());
     /// cache.put(3, "c");
     /// cache.put(4, "d");
     ///
@@ -778,13 +795,13 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     /// assert_eq!(cache.get(&3), Some(&"c"));
     /// assert_eq!(cache.get(&4), Some(&"d"));
     /// ```
-    pub fn resize(&mut self, cap: usize) {
+    pub fn resize(&mut self, cap: NonZeroUsize) {
         // return early if capacity doesn't change
         if cap == self.cap {
             return;
         }
 
-        while self.map.len() > cap {
+        while self.map.len() > cap.get() {
             self.pop_lru();
         }
         self.map.shrink_to_fit();
@@ -798,7 +815,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     ///
     /// ```
     /// use lru::LruCache;
-    /// let mut cache: LruCache<isize, &str> = LruCache::new(2);
+    /// use std::num::NonZeroUsize;
+    /// let mut cache: LruCache<isize, &str> = LruCache::new(NonZeroUsize::new(2).unwrap());
     /// assert_eq!(cache.len(), 0);
     ///
     /// cache.put(1, "a");
@@ -821,8 +839,9 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     ///
     /// ```
     /// use lru::LruCache;
+    /// use std::num::NonZeroUsize;
     ///
-    /// let mut cache = LruCache::new(3);
+    /// let mut cache = LruCache::new(NonZeroUsize::new(3).unwrap());
     /// cache.put("a", 1);
     /// cache.put("b", 2);
     /// cache.put("c", 3);
@@ -847,13 +866,14 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     ///
     /// ```
     /// use lru::LruCache;
+    /// use std::num::NonZeroUsize;
     ///
     /// struct HddBlock {
     ///     dirty: bool,
     ///     data: [u8; 512]
     /// }
     ///
-    /// let mut cache = LruCache::new(3);
+    /// let mut cache = LruCache::new(NonZeroUsize::new(3).unwrap());
     /// cache.put(0, HddBlock { dirty: false, data: [0x00; 512]});
     /// cache.put(1, HddBlock { dirty: true,  data: [0x55; 512]});
     /// cache.put(2, HddBlock { dirty: true,  data: [0x77; 512]});
@@ -1147,7 +1167,7 @@ impl<K: Hash + Eq, V> IntoIterator for LruCache<K, V> {
 #[cfg(test)]
 mod tests {
     use super::LruCache;
-    use core::fmt::Debug;
+    use core::{fmt::Debug, num::NonZeroUsize};
     use scoped_threadpool::Pool;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -1193,10 +1213,12 @@ mod tests {
     #[test]
     #[cfg(feature = "hashbrown")]
     fn test_with_hasher() {
+        use core::num::NonZeroUsize;
+
         use hashbrown::hash_map::DefaultHashBuilder;
 
         let s = DefaultHashBuilder::default();
-        let mut cache = LruCache::with_hasher(16, s);
+        let mut cache = LruCache::with_hasher(NonZeroUsize::new(16).unwrap(), s);
 
         for i in 0..13370 {
             cache.put(i, ());
@@ -1206,13 +1228,13 @@ mod tests {
 
     #[test]
     fn test_put_and_get() {
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
         assert!(cache.is_empty());
 
         assert_eq!(cache.put("apple", "red"), None);
         assert_eq!(cache.put("banana", "yellow"), None);
 
-        assert_eq!(cache.cap(), 2);
+        assert_eq!(cache.cap().get(), 2);
         assert_eq!(cache.len(), 2);
         assert!(!cache.is_empty());
         assert_opt_eq(cache.get(&"apple"), "red");
@@ -1221,29 +1243,29 @@ mod tests {
 
     #[test]
     fn test_put_and_get_or_insert() {
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
         assert!(cache.is_empty());
 
         assert_eq!(cache.put("apple", "red"), None);
         assert_eq!(cache.put("banana", "yellow"), None);
 
-        assert_eq!(cache.cap(), 2);
+        assert_eq!(cache.cap().get(), 2);
         assert_eq!(cache.len(), 2);
         assert!(!cache.is_empty());
-        assert_opt_eq(cache.get_or_insert(&"apple", || "orange"), &"red");
-        assert_opt_eq(cache.get_or_insert(&"banana", || "orange"), &"yellow");
-        assert_opt_eq(cache.get_or_insert(&"lemon", || "orange"), &"orange");
-        assert_opt_eq(cache.get_or_insert(&"lemon", || "red"), &"orange");
+        assert_eq!(cache.get_or_insert(&"apple", || "orange"), &"red");
+        assert_eq!(cache.get_or_insert(&"banana", || "orange"), &"yellow");
+        assert_eq!(cache.get_or_insert(&"lemon", || "orange"), &"orange");
+        assert_eq!(cache.get_or_insert(&"lemon", || "red"), &"orange");
     }
 
     #[test]
     fn test_put_and_get_mut() {
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
 
         cache.put("apple", "red");
         cache.put("banana", "yellow");
 
-        assert_eq!(cache.cap(), 2);
+        assert_eq!(cache.cap().get(), 2);
         assert_eq!(cache.len(), 2);
         assert_opt_eq_mut(cache.get_mut(&"apple"), "red");
         assert_opt_eq_mut(cache.get_mut(&"banana"), "yellow");
@@ -1251,7 +1273,7 @@ mod tests {
 
     #[test]
     fn test_get_mut_and_update() {
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
 
         cache.put("apple", 1);
         cache.put("banana", 3);
@@ -1261,7 +1283,7 @@ mod tests {
             *v = 4;
         }
 
-        assert_eq!(cache.cap(), 2);
+        assert_eq!(cache.cap().get(), 2);
         assert_eq!(cache.len(), 2);
         assert_opt_eq_mut(cache.get_mut(&"apple"), 4);
         assert_opt_eq_mut(cache.get_mut(&"banana"), 3);
@@ -1269,7 +1291,7 @@ mod tests {
 
     #[test]
     fn test_put_update() {
-        let mut cache = LruCache::new(1);
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
 
         assert_eq!(cache.put("apple", "red"), None);
         assert_eq!(cache.put("apple", "green"), Some("red"));
@@ -1280,7 +1302,7 @@ mod tests {
 
     #[test]
     fn test_put_removes_oldest() {
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
 
         assert_eq!(cache.put("apple", "red"), None);
         assert_eq!(cache.put("banana", "yellow"), None);
@@ -1302,7 +1324,7 @@ mod tests {
 
     #[test]
     fn test_peek() {
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
 
         cache.put("apple", "red");
         cache.put("banana", "yellow");
@@ -1319,7 +1341,7 @@ mod tests {
 
     #[test]
     fn test_peek_mut() {
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
 
         cache.put("apple", "red");
         cache.put("banana", "yellow");
@@ -1344,7 +1366,7 @@ mod tests {
 
     #[test]
     fn test_peek_lru() {
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
 
         assert!(cache.peek_lru().is_none());
 
@@ -1361,7 +1383,7 @@ mod tests {
 
     #[test]
     fn test_contains() {
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
 
         cache.put("apple", "red");
         cache.put("banana", "yellow");
@@ -1374,7 +1396,7 @@ mod tests {
 
     #[test]
     fn test_pop() {
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
 
         cache.put("apple", "red");
         cache.put("banana", "yellow");
@@ -1393,7 +1415,7 @@ mod tests {
 
     #[test]
     fn test_pop_entry() {
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
         cache.put("apple", "red");
         cache.put("banana", "yellow");
 
@@ -1411,7 +1433,7 @@ mod tests {
 
     #[test]
     fn test_pop_lru() {
-        let mut cache = LruCache::new(200);
+        let mut cache = LruCache::new(NonZeroUsize::new(200).unwrap());
 
         for i in 0..75 {
             cache.put(i, "A");
@@ -1446,7 +1468,7 @@ mod tests {
 
     #[test]
     fn test_clear() {
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
 
         cache.put("apple", "red");
         cache.put("banana", "yellow");
@@ -1461,11 +1483,11 @@ mod tests {
 
     #[test]
     fn test_resize_larger() {
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
 
         cache.put(1, "a");
         cache.put(2, "b");
-        cache.resize(4);
+        cache.resize(NonZeroUsize::new(4).unwrap());
         cache.put(3, "c");
         cache.put(4, "d");
 
@@ -1478,14 +1500,14 @@ mod tests {
 
     #[test]
     fn test_resize_smaller() {
-        let mut cache = LruCache::new(4);
+        let mut cache = LruCache::new(NonZeroUsize::new(4).unwrap());
 
         cache.put(1, "a");
         cache.put(2, "b");
         cache.put(3, "c");
         cache.put(4, "d");
 
-        cache.resize(2);
+        cache.resize(NonZeroUsize::new(2).unwrap());
 
         assert_eq!(cache.len(), 2);
         assert!(cache.get(&1).is_none());
@@ -1498,7 +1520,7 @@ mod tests {
     fn test_send() {
         use std::thread;
 
-        let mut cache = LruCache::new(4);
+        let mut cache = LruCache::new(NonZeroUsize::new(4).unwrap());
         cache.put(1, "a");
 
         let handle = thread::spawn(move || {
@@ -1511,7 +1533,7 @@ mod tests {
     #[test]
     fn test_multiple_threads() {
         let mut pool = Pool::new(1);
-        let mut cache = LruCache::new(4);
+        let mut cache = LruCache::new(NonZeroUsize::new(4).unwrap());
         cache.put(1, "a");
 
         let cache_ref = &cache;
@@ -1526,7 +1548,7 @@ mod tests {
 
     #[test]
     fn test_iter_forwards() {
-        let mut cache = LruCache::new(3);
+        let mut cache = LruCache::new(NonZeroUsize::new(3).unwrap());
         cache.put("a", 1);
         cache.put("b", 2);
         cache.put("c", 3);
@@ -1565,7 +1587,7 @@ mod tests {
 
     #[test]
     fn test_iter_backwards() {
-        let mut cache = LruCache::new(3);
+        let mut cache = LruCache::new(NonZeroUsize::new(3).unwrap());
         cache.put("a", 1);
         cache.put("b", 2);
         cache.put("c", 3);
@@ -1605,7 +1627,7 @@ mod tests {
 
     #[test]
     fn test_iter_forwards_and_backwards() {
-        let mut cache = LruCache::new(3);
+        let mut cache = LruCache::new(NonZeroUsize::new(3).unwrap());
         cache.put("a", 1);
         cache.put("b", 2);
         cache.put("c", 3);
@@ -1645,7 +1667,7 @@ mod tests {
     #[test]
     fn test_iter_multiple_threads() {
         let mut pool = Pool::new(1);
-        let mut cache = LruCache::new(3);
+        let mut cache = LruCache::new(NonZeroUsize::new(3).unwrap());
         cache.put("a", 1);
         cache.put("b", 2);
         cache.put("c", 3);
@@ -1673,7 +1695,7 @@ mod tests {
 
     #[test]
     fn test_iter_clone() {
-        let mut cache = LruCache::new(3);
+        let mut cache = LruCache::new(NonZeroUsize::new(3).unwrap());
         cache.put("a", 1);
         cache.put("b", 2);
 
@@ -1698,7 +1720,7 @@ mod tests {
 
     #[test]
     fn test_into_iter() {
-        let mut cache = LruCache::new(3);
+        let mut cache = LruCache::new(NonZeroUsize::new(3).unwrap());
         cache.put("a", 1);
         cache.put("b", 2);
         cache.put("c", 3);
@@ -1719,7 +1741,7 @@ mod tests {
 
     #[test]
     fn test_that_pop_actually_detaches_node() {
-        let mut cache = LruCache::new(5);
+        let mut cache = LruCache::new(NonZeroUsize::new(5).unwrap());
 
         cache.put("a", 1);
         cache.put("b", 2);
@@ -1744,7 +1766,7 @@ mod tests {
     fn test_get_with_borrow() {
         use alloc::string::String;
 
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
 
         let key = String::from("apple");
         cache.put(key, "red");
@@ -1756,7 +1778,7 @@ mod tests {
     fn test_get_mut_with_borrow() {
         use alloc::string::String;
 
-        let mut cache = LruCache::new(2);
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
 
         let key = String::from("apple");
         cache.put(key, "red");
@@ -1778,7 +1800,7 @@ mod tests {
 
         let n = 100;
         for _ in 0..n {
-            let mut cache = LruCache::new(1);
+            let mut cache = LruCache::new(NonZeroUsize::new(1).unwrap());
             for i in 0..n {
                 cache.put(i, DropCounter {});
             }
@@ -1800,7 +1822,7 @@ mod tests {
 
         let n = 100;
         for _ in 0..n {
-            let mut cache = LruCache::new(1);
+            let mut cache = LruCache::new(NonZeroUsize::new(1).unwrap());
             for i in 0..n {
                 cache.put(i, DropCounter {});
             }
@@ -1823,11 +1845,11 @@ mod tests {
 
         let n = 100;
         for _ in 0..n {
-            let mut cache = LruCache::new(1);
+            let mut cache = LruCache::new(NonZeroUsize::new(1).unwrap());
             for i in 0..n {
                 cache.put(i, DropCounter {});
             }
-            cache.resize(0);
+            cache.clear();
         }
         assert_eq!(DROP_COUNT.load(Ordering::SeqCst), n * n);
     }
@@ -1853,7 +1875,7 @@ mod tests {
 
         let n = 100;
         for _ in 0..n {
-            let mut cache = LruCache::new(1);
+            let mut cache = LruCache::new(NonZeroUsize::new(1).unwrap());
 
             for i in 0..100 {
                 cache.put(KeyDropCounter(i), i);
@@ -1862,11 +1884,5 @@ mod tests {
         }
 
         assert_eq!(DROP_COUNT.load(Ordering::SeqCst), n * n * 2);
-    }
-
-    #[test]
-    fn test_zero_cap_no_crash() {
-        let mut cache = LruCache::new(0);
-        cache.put("reizeiin", "tohka");
     }
 }


### PR DESCRIPTION
There is no use for LRU with zero capacity. Using NonZeroUsize for the `cap` field ensures that the state of zero capacity is unreachable and simplifies the logic. 

Pros:
* Simplified logic, where zero capacity is avoided. A bit easier to extend the LRU functionality.
* Improved and simplified `get_or_insert` API (no need to return `Option`)

Cons:
* Additional `use` statements to doc. 
* Breaks previous API that uses the `cap` field