### PR TITLE
Add API to explicitly control LRUness of keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `LruCache::promote` and `LruCache::demote` API to manipulate LRU order of the entry directly.
+
 ## [v0.7.8](https://github.com/jeromefroe/lru-rs/tree/0.7.8) - 2022-07-19
 
 - Update dependency on hashbrown to 0.12.


### PR DESCRIPTION
`promote` is mostly just `get`. `demote` is new, and wasn't expressible
before: it allows the caller to hint that the value likely won't be used
in the future.

The context I need this is https://github.com/near/nearcore/pull/7429. Basically, we have a functional (persistent, versioned) tree stored in the database, and we have an `lru` in-memory  cache of nodes on top of it. The most recent version of the tree is what's accessed most of the times, but historical versions are occasionally accessed as well. So, when we "remove" a node from a tree, we want to mark the cached version as a likely candidate for eviction, but we don't quite want to delete it outright, as it still might be useful if someone looks at the previous version. 


If you are generally onboard with the API, I'll work on proper doc comments, tests, and making sure I don't mess up linked list manipulation :)


Open to suggestion on the naming: promote/demote work OK, but not quite perfect. `touch` would be ideal for `promote`, but it doesn't  have a catchy antonym it seems. 