### PR TITLE
Add categories to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lru"
 version = "0.8.0"
 authors = ["Jerome Froelich <jeromefroelic@hotmail.com>"]
+categories = ["caching", "no-std"]
 description = "A LRU cache implementation"
 homepage = "https://github.com/jeromefroe/lru-rs"
 repository = "https://github.com/jeromefroe/lru-rs.git"


### PR DESCRIPTION
I was trying to figure out of this crate supported `no_std` environments while browsing https://crates.io/crates/lru. Mark it as being part of the `no-std` (and `caching`) categories to make it clearer.

The list of valid categories is [here](https://crates.io/category_slugs).