### PR TITLE
Bump `hashbrown` to 0.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.61.0  # MSRV
+          - 1.64.0  # MSRV
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = ["hashbrown"]
 nightly = ["hashbrown", "hashbrown/nightly"]
 
 [dependencies]
-hashbrown = { version = "0.13", optional = true }
+hashbrown = { version = "0.14", optional = true }
 
 [dev-dependencies]
 scoped_threadpool = "0.1.*"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An implementation of a LRU cache. The cache supports `put`, `get`, `get_mut` and
 all of which are O(1). This crate was heavily influenced by the [LRU Cache implementation in an
 earlier version of Rust's std::collections crate].
 
-The MSRV for this crate is 1.61.0.
+The MSRV for this crate is 1.64.0.
 
 ## Example
 


### PR DESCRIPTION
This increases the MSRV to 1.64.0 due to https://github.com/rust-lang/hashbrown/pull/431
