### PR TITLE
reverts use of NonZeroUsize for LRU capacity instead of usize

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,9 @@ Below is a simple example of how to instantiate and use a LRU cache.
 extern crate lru;
 
 use lru::LruCache;
-use std::num::NonZeroUsize;
 
 fn main() {
-    let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
+    let mut cache = LruCache::new(2);
     cache.put("apple", 3);
     cache.put("banana", 2);
 


### PR DESCRIPTION
NonZeroUsize for capacity is very nonergonomic and prevents some use-cases. For example a usize allows to disable caching by using capacity zero. see: https://github.com/jeromefroe/lru-rs/issues/165

This reverts commit 0e415efd09eda0faaa96d7704f47ef9827abe7e4.