### PR TITLE
adds value-wrapper for borrowed or owned return values

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,9 @@ Below is a simple example of how to instantiate and use a LRU cache.
 extern crate lru;
 
 use lru::LruCache;
-use std::num::NonZeroUsize;
 
 fn main() {
-    let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
+    let mut cache = LruCache::new(2);
     cache.put("apple", 3);
     cache.put("banana", 2);
 


### PR DESCRIPTION
```diff
- This is on top of:
- https://github.com/jeromefroe/lru-rs/pull/176
- Only the last commit is new code.
- I will rebase once #176 is merged.
```

`get_or_insert`, `get_or_insert_mut` and `try_get_or_insert` may return `None` only in the case where capacity is zero.
Instead this commit adds a `ValueWrapper`:

    enum ValueWrapper<'a, V> {
        Borrowed(&'a V),
        Owned(V),
    }

which makes it possible for these methods to always return a value which can be borrowed as V.
