### PR TITLE
Update hashbrown dependency to version 0.15.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = ["hashbrown"]
 nightly = ["hashbrown", "hashbrown/nightly"]
 
 [dependencies]
-hashbrown = { version = "0.15", optional = true }
+hashbrown = { version = "0.15.2", optional = true }
 
 [dev-dependencies]
 scoped_threadpool = "0.1.*"


### PR DESCRIPTION
Resolve https://rustsec.org/advisories/RUSTSEC-2024-0402