### PR TITLE
Update hashbrown to 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default = ["hashbrown"]
 nightly = ["hashbrown", "hashbrown/nightly"]
 
 [dependencies]
-hashbrown = { version = "0.15.2", optional = true }
+hashbrown = { version = "0.16.0", optional = true }
 
 [dev-dependencies]
 scoped_threadpool = "0.1.*"


### PR DESCRIPTION
Following up https://github.com/jeromefroe/lru-rs/pull/204.

This would let us not pull in a third copy of hashbrown with https://github.com/ruffle-rs/ruffle/pull/21895 (pending a few other similar crate updates and releases), since `wgpu` 27 now has this dependency: https://github.com/gfx-rs/wgpu/pull/8194