### PR TITLE
Fix `IterMut` Stacked Borrows violation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2850,6 +2850,22 @@ mod tests {
         assert_eq!(cache.pop_lru(), None);
         assert_eq!(cloned.pop_lru(), None);
     }
+
+    #[test]
+    fn iter_mut_stacked_borrows_violation() {
+        let mut cache: LruCache<i32, i32> = LruCache::new(NonZeroUsize::new(3).unwrap());
+        cache.put(1, 10);
+        cache.put(2, 20);
+        cache.put(3, 30);
+
+        for (_k, v) in cache.iter_mut() {
+            *v *= 2;
+        }
+
+        assert_eq!(cache.get(&1), Some(&20));
+        assert_eq!(cache.get(&2), Some(&40));
+        assert_eq!(cache.get(&3), Some(&60));
+    }
 }
 
 /// Doctests for what should *not* compile

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1733,7 +1733,7 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
             return None;
         }
 
-        let key = unsafe { &mut (*(*self.ptr).key.as_mut_ptr()) as &mut K };
+        let key = unsafe { &(*(*self.ptr).key.as_ptr()) as &K };
         let val = unsafe { &mut (*(*self.ptr).val.as_mut_ptr()) as &mut V };
 
         self.len -= 1;
@@ -1757,7 +1757,7 @@ impl<'a, K, V> DoubleEndedIterator for IterMut<'a, K, V> {
             return None;
         }
 
-        let key = unsafe { &mut (*(*self.end).key.as_mut_ptr()) as &mut K };
+        let key = unsafe { &(*(*self.end).key.as_ptr()) as &K };
         let val = unsafe { &mut (*(*self.end).val.as_mut_ptr()) as &mut V };
 
         self.len -= 1;


### PR DESCRIPTION
This fixes a Stacked Borrows violation in `IterMut`. The issue was that `IterMut::next` and `IterMut::next_back` temporarily create an exclusive reference to the key. This invalidates the pointer held within `KeyWrapper` by the `HashMap`, but the HashMap still holds and accesses it on subsequent reads or writes to the LRU, which is unsound.

The implementation silently coerces the esclusive reference into a shared reference, but this does not undo the effect of the exclusive reference.

This can be seen by running miri on the test that I've added in the second commit without the fix in the first commit.

The solution is to use shared references throughout, rather than first requesting an exclusive reference and then converting it into a shared reference.

```
test tests::iter_mut_stacked_borrows_violation ... error: Undefined Behavior: trying to retag from <175909> for SharedReadOnly permission at alloc52275[0x10], but that tag does not exist in the borrow stack for this location
    --> src/lib.rs:147:28
     |
 147 |         let key = unsafe { &*self.k }.borrow();
     |                            ^^^^^^^^ this error occurs as part of retag at alloc52275[0x10..0x14]
     |
     = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
     = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
help: <175909> was created by a SharedReadOnly retag at offsets [0x10..0x14]
    --> src/lib.rs:387:39
     |
 387 |                 let keyref = unsafe { (*node_ptr).key.as_ptr() };
     |                                       ^^^^^^^^^^^^^^^^^^^^^^^^
help: <175909> was later invalidated at offsets [0x10..0x14] by a Unique function-entry retag inside this call
    --> src/lib.rs:1736:35
     |
1736 |         let key = unsafe { &mut (*(*self.ptr).key.as_mut_ptr()) as &mut K };
     |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = note: this is on thread `tests::iter_mut`
     = note: stack backtrace:
             0: <KeyRef<i32> as core::borrow::Borrow<KeyWrapper<i32>>>::borrow
                 at src/lib.rs:147:28: 147:36
             1: <KeyWrapper<i32> as hashbrown::Equivalent<KeyRef<i32>>>::equivalent
                 at /home/paolobarbolini/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/equivalent-1.0.2/src/lib.rs:89:29: 89:41
             2: hashbrown::map::equivalent_key::<KeyWrapper<i32>, KeyRef<i32>, core::ptr::NonNull<LruEntry<i32, i32>>>::{closure#0}
                 at /home/paolobarbolini/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hashbrown-0.16.1/src/map.rs:224:14: 224:32
             3: hashbrown::raw::RawTable::<(KeyRef<i32>, core::ptr::NonNull<LruEntry<i32, i32>>)>::find::<{closure@hashbrown::map::equivalent_key<KeyWrapper<i32>, KeyRef<i32>, core::ptr::NonNull<LruEntry<i32, i32>>>::{closure#0}}>::{closure#0}
                 at /home/paolobarbolini/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hashbrown-0.16.1/src/raw/mod.rs:1236:48: 1236:79
             4: hashbrown::raw::RawTableInner::find_inner
                 at /home/paolobarbolini/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hashbrown-0.16.1/src/raw/mod.rs:2075:27: 2075:36
             5: hashbrown::raw::RawTable::<(KeyRef<i32>, core::ptr::NonNull<LruEntry<i32, i32>>)>::find::<{closure@hashbrown::map::equivalent_key<KeyWrapper<i32>, KeyRef<i32>, core::ptr::NonNull<LruEntry<i32, i32>>>::{closure#0}}>
                 at /home/paolobarbolini/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hashbrown-0.16.1/src/raw/mod.rs:1234:26: 1236:80
             6: hashbrown::raw::RawTable::<(KeyRef<i32>, core::ptr::NonNull<LruEntry<i32, i32>>)>::get_mut::<{closure@hashbrown::map::equivalent_key<KeyWrapper<i32>, KeyRef<i32>, core::ptr::NonNull<LruEntry<i32, i32>>>::{closure#0}}>
                 at /home/paolobarbolini/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hashbrown-0.16.1/src/raw/mod.rs:1261:15: 1261:34
             7: hashbrown::HashMap::<KeyRef<i32>, core::ptr::NonNull<LruEntry<i32, i32>>>::get_mut::<KeyWrapper<i32>>
                 at /home/paolobarbolini/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hashbrown-0.16.1/src/map.rs:1459:19: 1459:62
             8: LruCache::<i32, i32>::get::<i32>
                 at src/lib.rs:451:29: 451:70
             9: tests::iter_mut_stacked_borrows_violation
                 at src/lib.rs:2865:20: 2865:33
             10: tests::iter_mut_stacked_borrows_violation::{closure#0}
                 at src/lib.rs:2855:44: 2855:44

note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

error: aborting due to 1 previous error

error: test failed, to rerun pass `--lib`

Caused by:
  process didn't exit successfully: `/home/paolobarbolini/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/bin/cargo-miri runner /tmp/lru-rs/target/miri/x86_64-unknown-linux-gnu/debug/deps/lru-560d2b17fca9fce5 iter_mut_stacked_borrows_violation` (exit status: 1)
note: test exited abnormally; to see the full output pass --no-capture to the harness.
```