### PR TITLE
Add get_or_insert_with_key

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -871,7 +871,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
         self.get_or_insert_mut_with_key(k, |_| f())
     }
 
-    /// Returns a reference to the value of the key in the cache if it is
+    /// Returns a mutable reference to the value of the key in the cache if it is
     /// present in the cache and moves the key to the head of the LRU list.
     /// If the key does not exist the provided `FnOnce` is used by passing
     /// a reference to the key to populate the list and a mutable reference
@@ -1003,7 +1003,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
         self.try_get_or_insert_mut_with_key(k, |_| f())
     }
 
-    /// Returns a reference to the value of the key in the cache if it is
+    /// Returns a mutable reference to the value of the key in the cache if it is
     /// present in the cache and moves the key to the head of the LRU list.
     /// If the key does not exist the provided `FnOnce` is used by passing
     /// a reference to the key to populate the list and a mutable reference

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -602,6 +602,35 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     where
         F: FnOnce() -> V,
     {
+        self.get_or_insert_with_key(k, |_| f())
+    }
+
+    /// Returns a reference to the value of the key in the cache if it is
+    /// present in the cache and moves the key to the head of the LRU list.
+    /// If the key does not exist the provided `FnOnce` is used by passing
+    /// a reference to the key to populate the list and a reference is returned.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lru::LruCache;
+    /// use std::num::NonZeroUsize;
+    /// let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
+    ///
+    /// cache.put("One", 1);
+    /// cache.put("Two", 2);
+    /// cache.put("Two", 3);
+    /// cache.put("Three", 4);
+    ///
+    /// assert_eq!(cache.get_or_insert_with_key("Two", |_|1), &3);
+    /// assert_eq!(cache.get_or_insert_with_key("Three", |k|k.len()), &4);
+    /// assert_eq!(cache.get_or_insert_with_key("One", |_|1), &1);
+    /// assert_eq!(cache.get_or_insert_with_key("One", |k|k.len()), &1);
+    /// ```
+    pub fn get_or_insert_with_key<F>(&mut self, k: K, f: F) -> &V
+    where
+        F: FnOnce(&K) -> V,
+    {
         if let Some(node) = self.map.get_mut(&KeyRef { k: &k }) {
             let node_ptr: *mut LruEntry<K, V> = node.as_ptr();
 
@@ -610,7 +639,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
 
             unsafe { &*(*node_ptr).val.as_ptr() }
         } else {
-            let v = f();
+            let v = f(&k);
             let (_, node) = self.replace_or_create_node(k, v);
             let node_ptr: *mut LruEntry<K, V> = node.as_ptr();
 
@@ -704,6 +733,40 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     where
         F: FnOnce() -> Result<V, E>,
     {
+        self.try_get_or_insert_with_key(k, |_| f())
+    }
+
+    /// Returns a reference to the value of the key in the cache if it is
+    /// present in the cache and moves the key to the head of the LRU list.
+    /// If the key does not exist the provided `FnOnce` is used by passing
+    /// a reference to the key to populate the list and a reference is returned.
+    /// If `FnOnce` returns `Err`, returns the `Err`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lru::LruCache;
+    /// use std::num::NonZeroUsize;
+    /// let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
+    ///
+    /// cache.put("One", 1);
+    /// cache.put("Two", 2);
+    /// cache.put("Two", 3);
+    /// cache.put("Three", 4);
+    ///
+    /// let f = |_: &&str|->Result<usize, String> {Err("failed".to_owned())};
+    /// let len = |k: &&str|->Result<usize, String> {Ok(k.len())};
+    /// let zero = |_: &&str|->Result<usize, String> {Ok(0)};
+    /// assert_eq!(cache.try_get_or_insert_with_key("Two", len), Ok(&3));
+    /// assert_eq!(cache.try_get_or_insert_with_key("Three", len), Ok(&4));
+    /// assert_eq!(cache.try_get_or_insert_with_key("Four", f), Err("failed".to_owned()));
+    /// assert_eq!(cache.try_get_or_insert_with_key("Five", len), Ok(&4));
+    /// assert_eq!(cache.try_get_or_insert_with_key("Five", zero), Ok(&4));
+    /// ```
+    pub fn try_get_or_insert_with_key<F, E>(&mut self, k: K, f: F) -> Result<&V, E>
+    where
+        F: FnOnce(&K) -> Result<V, E>,
+    {
         if let Some(node) = self.map.get_mut(&KeyRef { k: &k }) {
             let node_ptr: *mut LruEntry<K, V> = node.as_ptr();
 
@@ -712,7 +775,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
 
             unsafe { Ok(&*(*node_ptr).val.as_ptr()) }
         } else {
-            let v = f()?;
+            let v = f(&k)?;
             let (_, node) = self.replace_or_create_node(k, v);
             let node_ptr: *mut LruEntry<K, V> = node.as_ptr();
 
@@ -805,6 +868,36 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     where
         F: FnOnce() -> V,
     {
+        self.get_or_insert_mut_with_key(k, |_| f())
+    }
+
+    /// Returns a reference to the value of the key in the cache if it is
+    /// present in the cache and moves the key to the head of the LRU list.
+    /// If the key does not exist the provided `FnOnce` is used by passing
+    /// a reference to the key to populate the list and a mutable reference
+    /// is returned.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lru::LruCache;
+    /// use std::num::NonZeroUsize;
+    /// let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
+    ///
+    /// cache.put("One", 1);
+    /// cache.put("Two", 2);
+    /// cache.put("Two", 3);
+    /// cache.put("Three", 4);
+    ///
+    /// assert_eq!(cache.get_or_insert_mut_with_key("Two", |_|1), &mut 3);
+    /// assert_eq!(cache.get_or_insert_mut_with_key("Three", |k|k.len()), &mut 4);
+    /// assert_eq!(cache.get_or_insert_mut_with_key("One", |_|1), &mut 1);
+    /// assert_eq!(cache.get_or_insert_mut_with_key("One", |k|k.len()), &mut 1);
+    /// ```
+    pub fn get_or_insert_mut_with_key<F>(&mut self, k: K, f: F) -> &mut V
+    where
+        F: FnOnce(&K) -> V,
+    {
         if let Some(node) = self.map.get_mut(&KeyRef { k: &k }) {
             let node_ptr: *mut LruEntry<K, V> = node.as_ptr();
 
@@ -813,7 +906,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
 
             unsafe { &mut *(*node_ptr).val.as_mut_ptr() }
         } else {
-            let v = f();
+            let v = f(&k);
             let (_, node) = self.replace_or_create_node(k, v);
             let node_ptr: *mut LruEntry<K, V> = node.as_ptr();
 
@@ -907,6 +1000,40 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     where
         F: FnOnce() -> Result<V, E>,
     {
+        self.try_get_or_insert_mut_with_key(k, |_| f())
+    }
+
+    /// Returns a reference to the value of the key in the cache if it is
+    /// present in the cache and moves the key to the head of the LRU list.
+    /// If the key does not exist the provided `FnOnce` is used by passing
+    /// a reference to the key to populate the list and a mutable reference
+    /// is returned. If `FnOnce` returns `Err`, returns the `Err`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lru::LruCache;
+    /// use std::num::NonZeroUsize;
+    /// let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
+    ///
+    /// cache.put("One", 1);
+    /// cache.put("Two", 2);
+    /// cache.put("Two", 3);
+    /// cache.put("Three", 4);
+    ///
+    /// let f = |_: &&str|->Result<usize, String> {Err("failed".to_owned())};
+    /// let len = |k: &&str|->Result<usize, String> {Ok(k.len())};
+    /// let zero = |_: &&str|->Result<usize, String> {Ok(0)};
+    /// assert_eq!(cache.try_get_or_insert_mut_with_key("Two", len), Ok(&mut 3));
+    /// assert_eq!(cache.try_get_or_insert_mut_with_key("Three", len), Ok(&mut 4));
+    /// assert_eq!(cache.try_get_or_insert_mut_with_key("Four", f), Err("failed".to_owned()));
+    /// assert_eq!(cache.try_get_or_insert_mut_with_key("Five", len), Ok(&mut 4));
+    /// assert_eq!(cache.try_get_or_insert_mut_with_key("Five", zero), Ok(&mut 4));
+    /// ```
+    pub fn try_get_or_insert_mut_with_key<F, E>(&mut self, k: K, f: F) -> Result<&mut V, E>
+    where
+        F: FnOnce(&K) -> Result<V, E>,
+    {
         if let Some(node) = self.map.get_mut(&KeyRef { k: &k }) {
             let node_ptr: *mut LruEntry<K, V> = node.as_ptr();
 
@@ -915,7 +1042,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
 
             unsafe { Ok(&mut *(*node_ptr).val.as_mut_ptr()) }
         } else {
-            let v = f()?;
+            let v = f(&k)?;
             let (_, node) = self.replace_or_create_node(k, v);
             let node_ptr: *mut LruEntry<K, V> = node.as_ptr();
 
@@ -1917,6 +2044,23 @@ mod tests {
     }
 
     #[test]
+    fn test_put_and_get_or_insert_with_key() {
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
+        assert!(cache.is_empty());
+
+        assert_eq!(cache.put("apple", 2), None);
+        assert_eq!(cache.put("banana", 8), None);
+
+        assert_eq!(cache.cap().get(), 2);
+        assert_eq!(cache.len(), 2);
+        assert!(!cache.is_empty());
+        assert_eq!(cache.get_or_insert_with_key("apple", |k| k.len()), &2);
+        assert_eq!(cache.get_or_insert_with_key("banana", |k| k.len()), &8);
+        assert_eq!(cache.get_or_insert_with_key("lemon", |k| k.len()), &5);
+        assert_eq!(cache.get_or_insert_with_key("lemon", |k| k.len() + 3), &5);
+    }
+
+    #[test]
     fn test_get_or_insert_ref() {
         use alloc::borrow::ToOwned;
         use alloc::string::String;
@@ -1968,6 +2112,32 @@ mod tests {
     }
 
     #[test]
+    fn test_try_get_or_insert_with_key() {
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
+
+        assert_eq!(
+            cache.try_get_or_insert_with_key::<_, &str>("apple", |k| Ok(k.len())),
+            Ok(&5)
+        );
+        assert_eq!(
+            cache.try_get_or_insert_with_key::<_, &str>("apple", |_| Err("failed")),
+            Ok(&5)
+        );
+        assert_eq!(
+            cache.try_get_or_insert_with_key::<_, &str>("banana", |k| Ok(k.len())),
+            Ok(&6)
+        );
+        assert_eq!(
+            cache.try_get_or_insert_with_key::<_, &str>("lemon", |_| Err("failed")),
+            Err("failed")
+        );
+        assert_eq!(
+            cache.try_get_or_insert_with_key::<_, &str>("banana", |_| Err("failed")),
+            Ok(&6)
+        );
+    }
+
+    #[test]
     fn test_try_get_or_insert_ref() {
         use alloc::borrow::ToOwned;
         use alloc::string::String;
@@ -2009,6 +2179,27 @@ mod tests {
     }
 
     #[test]
+    fn test_put_and_get_or_insert_mut_with_key() {
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
+        assert!(cache.is_empty());
+
+        assert_eq!(cache.put("apple", 2), None);
+        assert_eq!(cache.put("banana", 8), None);
+
+        assert_eq!(cache.cap().get(), 2);
+        assert_eq!(cache.len(), 2);
+
+        let v = cache.get_or_insert_mut_with_key("apple", |k| k.len());
+        assert_eq!(v, &2);
+        *v = 4;
+
+        assert_eq!(cache.get_or_insert_mut_with_key("apple", |k| k.len()), &4);
+        assert_eq!(cache.get_or_insert_mut_with_key("banana", |k| k.len()), &8);
+        assert_eq!(cache.get_or_insert_mut_with_key("lemon", |k| k.len()), &5);
+        assert_eq!(cache.get_or_insert_mut_with_key("lemon", |_| 0), &5);
+    }
+
+    #[test]
     fn test_get_or_insert_mut_ref() {
         use alloc::borrow::ToOwned;
         use alloc::string::String;
@@ -2042,6 +2233,35 @@ mod tests {
         assert_eq!(cache.try_get_or_insert_mut(3, f), Err("failed"));
         assert_eq!(cache.try_get_or_insert_mut(4, b), Ok(&mut "b"));
         assert_eq!(cache.try_get_or_insert_mut(4, a), Ok(&mut "b"));
+    }
+
+    #[test]
+    fn test_try_get_or_insert_mut_with_key() {
+        let mut cache = LruCache::new(NonZeroUsize::new(2).unwrap());
+
+        cache.put("One", 1);
+        cache.put("Two", 2);
+        cache.put("Two", 3);
+
+        let f = |_: &&str| -> Result<usize, &str> { Err("failed") };
+        let len = |k: &&str| -> Result<usize, &str> { Ok(k.len()) };
+        let zero = |_: &&str| -> Result<usize, &str> { Ok(0) };
+        if let Ok(v) = cache.try_get_or_insert_mut_with_key("Two", f) {
+            *v = 6;
+        }
+        assert_eq!(cache.try_get_or_insert_mut_with_key("Two", len), Ok(&mut 6));
+        assert_eq!(
+            cache.try_get_or_insert_mut_with_key("Three", f),
+            Err("failed")
+        );
+        assert_eq!(
+            cache.try_get_or_insert_mut_with_key("Four", len),
+            Ok(&mut 4)
+        );
+        assert_eq!(
+            cache.try_get_or_insert_mut_with_key("Four", zero),
+            Ok(&mut 4)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Add get_or_insert_with_key variant. If the key is needed to create a new value to populate the  cache, using only get_or_insert implies the use of a cloneable key to be able to capture the key in the provided closure. Wrapping the key with Rc and using get_or_insert_ref just for that seems overkill.

```rust
let key = Rc::new("mydomain.com".to_owned());
cache.get_or_insert_ref(&key, domain_cert_generator(key.clone()));

```
becomes:

```rust
cache.get_or_insert_with_key("mydomain.com".to_owned(), generate_domain_cert);
```