### PR TITLE
Fix unconstrained lifetime in `LruCache::get_or_insert_mut_ref`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -942,7 +942,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> LruCache<K, V, S> {
     /// assert_eq!(Rc::strong_count(&key2), 2); // key2 was only cloned once even though we
     ///                                         // queried it 2 times
     /// ```
-    pub fn get_or_insert_mut_ref<'a, Q, F>(&mut self, k: &'_ Q, f: F) -> &'a mut V
+    pub fn get_or_insert_mut_ref<'a, Q, F>(&'a mut self, k: &'_ Q, f: F) -> &'a mut V
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized + alloc::borrow::ToOwned<Owned = K>,


### PR DESCRIPTION
The following reproducer triggers UB in miri:

```rs
use std::num::NonZero;

use lru::LruCache;

fn leak() -> &'static mut String {
    let mut cache: LruCache<String, String> = LruCache::new(NonZero::new(1).unwrap());
    cache.get_or_insert_mut_ref::<str, _>("k", || "hello".to_string())
}

fn main() {
    let _ = leak();
}
```

```
error: Undefined Behavior: pointer not dereferenceable: alloc693 has been freed, so this pointer is dangling
 --> src/main.rs:7:5
  |
7 |     cache.get_or_insert_mut_ref::<str, _>("k", || "hello".to_string())
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
  |
  = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
  = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
help: alloc693 was allocated here:
 --> src/main.rs:7:5
  |
7 |     cache.get_or_insert_mut_ref::<str, _>("k", || "hello".to_string())
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: alloc693 was deallocated here:
 --> src/main.rs:8:1
  |
8 | }
  | ^
  = note: stack backtrace:
          0: leak
              at src/main.rs:7:5: 7:71
          1: main
              at src/main.rs:11:13: 11:19
```

This is because `LruCache::get_or_insert_mut_ref` does not tie the `'a` lifetime to `self`. As a result the caller can pick any lifetime for the returned reference, including `'static`, yielding a reference that outlives the cache.