### PR TITLE
Add LruCache::sparse()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,6 +232,20 @@ impl<K: Hash + Eq, V> LruCache<K, V> {
         LruCache::construct(cap, HashMap::with_capacity(cap.get()))
     }
 
+    /// Creates a new LRU Cache that holds at most `cap` items without allocating storage space
+    /// for them.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lru::LruCache;
+    /// use std::num::NonZeroUsize;
+    /// let mut cache: LruCache<isize, &str> = LruCache::sparse(NonZeroUsize::new(1_000_000).unwrap());
+    /// ```
+    pub fn sparse(cap: NonZeroUsize) -> LruCache<K, V> {
+        LruCache::construct(cap, HashMap::default())
+    }
+
     /// Creates a new LRU Cache that never automatically evicts items.
     ///
     /// # Example


### PR DESCRIPTION
I have a use case where I want to create many large-capacity LRUs where typical behavior is the LRU is not necessary.  `LruCache::new()` allocates a HashMap with a capacity matching the LRU capacity and I don't have PB of RAM that will not store LRU entries.

I currently use this workaround:

```rust
let mut lru = LruCache::new(NonZeroUsize::new(1).unwrap());
lru.resize(NonZeroUsize::new(actual_capacity).unwrap());
```

But I worry that a future change to `LruCache::resize()` will use `HashMap::reserve()`, expanding memory usage, and invalidate my workaround.